### PR TITLE
Фикс бага функционала добавления фильма

### DIFF
--- a/application/src/components/Movies/Movies.jsx
+++ b/application/src/components/Movies/Movies.jsx
@@ -32,7 +32,8 @@ class Movies extends React.Component {
       watched: false,
       rate: 0,
       directorId: '',
-      open: false
+      open: false,
+      id: null,
     });
   };
 


### PR DESCRIPTION
Починил баг, при котором получалось следующее: добавили фильм, исправили добавленный фильм, добавили еще один. В итоге старый заменяется на новый. Происходит из-за того, что в методе onClose в setState не обнуляем id фильма.